### PR TITLE
fix(withdraw): request close after authorized

### DIFF
--- a/src/settlement/machinomy.ts
+++ b/src/settlement/machinomy.ts
@@ -255,17 +255,18 @@ const withdraw = (uplink: ReadyMachinomyUplink) => async (
   let claimChannel: Promise<any>
 
   const isAuthorized = new Promise<any>((resolve, reject) => {
-    claimChannel = uplink.pluginAccount.claimIfProfitable(
-      false,
-      async (channel, fee) => {
+    claimChannel = uplink.pluginAccount
+      .claimIfProfitable(false, async (channel, fee) => {
         await authorize({
           value: uplink.outgoingCapacity$.value.plus(
             convert(wei(channel.spent), eth())
           ),
           fee: convert(wei(fee), eth())
         }).then(resolve, reject)
-      }
-    )
+      })
+      // If `authorize` is never called/fee calculation fails,
+      // also reject isAuthorized
+      .then(reject, reject)
   })
 
   // TODO This won't reject if the withdraw fails!

--- a/src/settlement/xrp-paychan.ts
+++ b/src/settlement/xrp-paychan.ts
@@ -25,8 +25,6 @@ import {
 import createLogger from '../utils/log'
 import { MemoryStore } from '../utils/store'
 
-const log = createLogger('switch-api:xrp-paychan')
-
 /**
  * ------------------------------------
  * SETTLEMENT ENGINE
@@ -299,10 +297,10 @@ const withdraw = (uplink: ReadyXrpPaychanUplink) => async (
           value: uplink.outgoingCapacity$.value.plus(
             convert(drop(channel.spent), xrp())
           ),
-          fee: convert(drop(fee), xrp())
+          fee
         }).then(resolve, reject)
       })
-      // If for `authorize` is never called/fee calculation fails,
+      // If `authorize` is never called/fee calculation fails,
       // also reject isAuthorized
       .then(reject, reject)
   })


### PR DESCRIPTION
- claiming channel and requesting peer to close previously happened in parallel
- wait for the withdraw to be authorized before requesting the peer to close the outgoing channel
